### PR TITLE
Bleach loaded before config

### DIFF
--- a/lib/sanitize_email/railtie.rb
+++ b/lib/sanitize_email/railtie.rb
@@ -4,7 +4,7 @@
 module SanitizeEmail
   class Railtie < ::Rails::Railtie
 
-    config.before_configuration do
+    config.after_initialize do
       ActionMailer::Base.register_interceptor(SanitizeEmail::Bleach.new)
     end
 


### PR DESCRIPTION
Rails 3.0.11 .. The railtie:

```
config.before_configuration do
      ActionMailer::Base.register_interceptor(SanitizeEmail::Bleach.new)
end
```

loads Bleach, which attempts to load the SanitizeEmail::Config information, before the initializer has run to set those values.
