### PR TITLE
Header strip to prevent empty illegal headers

### DIFF
--- a/lib/sanitize_email/bleach.rb
+++ b/lib/sanitize_email/bleach.rb
@@ -56,7 +56,7 @@ module SanitizeEmail
           # For each type of address line
           v.each { |a|
             # For each address
-            message.header = message.header.to_s + "\n#{k}: #{a}"
+            message.header = message.header.to_s.strip + "\n#{k}: #{a}"
           } if v
         }
     end


### PR DESCRIPTION
Stripping the message headers before we append.  In a scenario where there is a trailing space, adding the newline before we append results in a blank header which throws an error as illegal.

A problem existed such that the headers had a trailing space.  When the new header was appending with the beginning newline, it created headers like so:

```
Sent mail to foo@bar.com (1154ms)
Date: Thu, 01 Aug 2013 16:27:41 -0400
From: foo@bar.com
To: "foo @ bar.com" <foo@bar.com>
Subject: (foo @ bar.com) Test
Mime-Version: 1.0
Content-Type: text/plain;
 charset=UTF-8
Content-Transfer-Encoding: 7bit
:
X-Sanitize-Email-To: foo@bar.com
```

When it actually went to be parsed, we would get an error

```
Net::SMTPFatalError - 554 Transaction failed: Empty header names are illegal.
:
```

Simply stripping the headers resolves the problem.
