### PR TITLE
Don't sanitize an email that is not supposed to be delivered

### DIFF
--- a/lib/sanitize_email/bleach.rb
+++ b/lib/sanitize_email/bleach.rb
@@ -40,6 +40,9 @@ module SanitizeEmail
     # If installed but not configured, sanitize email DOES NOTHING.  Until configured the defaults leave it turned off.
     def sanitize_engaged?(message)
 
+      # Don't sanitize the message if it will not be delivered
+      return false unless message.perform_deliveries
+
       # Has it been forced via the force_sanitize mattr?
       forced = SanitizeEmail.force_sanitize
       return forced unless forced.nil?


### PR DESCRIPTION
Sometimes you don't want your message to be sent ( in specs, on some environments, or even inside and email method you want to prevent the message from being sent).

When the e-mail is marked as not deliverable, sanitize_email should not try to sanitize it.

Thanks !
