### PR TITLE
Fix handling of frozen strings

### DIFF
--- a/lib/sanitize_email/mail_header_tools.rb
+++ b/lib/sanitize_email/mail_header_tools.rb
@@ -55,9 +55,12 @@ module SanitizeEmail
 
     def self.prepend_custom_subject(message)
       message.subject = "" unless message.subject
-      message.subject.prepend(
-        SanitizeEmail::MailHeaderTools.custom_subject(message)
-      )
+      custom_subject = SanitizeEmail::MailHeaderTools.custom_subject(message)
+      if message.subject.frozen?
+        message.subject = "#{custom_subject}#{message.subject}"
+      else
+        message.subject.prepend(custom_subject)
+      end
     end
 
     # According to https://github.com/mikel/mail

--- a/spec/sanitize_email_spec.rb
+++ b/spec/sanitize_email_spec.rb
@@ -106,9 +106,24 @@ describe SanitizeEmail do
     end
   end
 
+  def sanitary_mail_delivery_frozen_strings(config_options = {})
+    SanitizeEmail.sanitary(config_options) do
+      mail_delivery_frozen_strings
+    end
+  end
+
   def unsanitary_mail_delivery
     SanitizeEmail.unsanitary do
       mail_delivery
+    end
+  end
+
+  def mail_delivery_frozen_strings
+    @email_message = Mail.deliver do
+      from      "from@example.org".freeze
+      to        "to@example.org".freeze
+      subject   "original subject".freeze
+      body      "funky fresh".freeze
     end
   end
 
@@ -467,6 +482,16 @@ describe SanitizeEmail do
         expect(@email_message).not_to have_subject(
           "(same at example.org) original subject"
         )
+      end
+    end
+
+    context "with frozen string (literals)" do
+      it "prepends strings without exception" do
+        configure_sanitize_email(
+          environment: "{{serverABC}}",
+          use_actual_environment_prepended_to_subject: true
+        )
+        expect { sanitary_mail_delivery_frozen_strings }.to_not raise_exception
       end
     end
 


### PR DESCRIPTION
Upgrading to Rails 5 we found that we have more and more frozen strings which would prevent invocation of `String#prepend`. This small patch checks whether the string is frozen and in that case construct a new string from it.