### PR TITLE
Travis: get latest Rubygems & Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,5 +71,8 @@ matrix:
 #      gemfile: gemfiles/rails_3_0.gemfile
 #    - rvm: 1.9
 #      gemfile: gemfiles/rails_3_1.gemfile
+before_install:
+  - gem update --system
+  - gem install bundler
 install:
   - bundle install


### PR DESCRIPTION
This PR fixes the build.

- add Rubygems 2.6.10
- add latest Bundler

All this is needed to install Rainbow, avoiding a frozen string issue in Rubygems.

**Update:** Squashed to 1 commit.