### PR TITLE
Don't use #prepend on subject

### DIFF
--- a/lib/sanitize_email/mail_header_tools.rb
+++ b/lib/sanitize_email/mail_header_tools.rb
@@ -57,7 +57,7 @@ module SanitizeEmail
     def self.prepend_custom_subject(message)
       message.subject = '' unless message.subject
       custom_subject = SanitizeEmail::MailHeaderTools.custom_subject(message)
-      +message.subject.prepend(custom_subject)
+      message.subject = custom_subject + message.subject
     end
 
     # According to https://github.com/mikel/mail


### PR DESCRIPTION
`#prepend` causes `message.subject` to be modified in-place.  It could be a use-supplied "constant" string, so modifying it would be impolite.

