### PR TITLE
Add support for sanitizing personalization fields from SendGrid

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,3 @@
 rubocop:
   config_file: .rubocop.yml
-  version: 0.58.2
+  version: 0.59.2

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+rubocop:
+  config_file: .rubocop.yml
+  version: 0.58.2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,6 @@ Style/ClassVars:
 
 Style/CollectionMethods:
   PreferredMethods:
-    map:      'collect'
     reduce:   'inject'
     find:     'detect'
     find_all: 'select'
@@ -65,6 +64,9 @@ Style/EmptyMethod:
 
 Style/Encoding:
   Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,5 +17,8 @@ Style/ExpandPathArguments:
 Style/CommentedKeyword:
   Enabled: false
 
-Style/MethodMissing:
+Style/MethodMissingSuper:
+  Enabled: false
+
+Style/MissingRespondToMissing:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   # Travis-CI does not support C-extensions on JRuby
   ruby_version = Gem::Version.new(RUBY_VERSION)
   if ruby_version >= Gem::Version.new('2.1')
-    gem 'rubocop', '~> 0.58.2', platforms: :mri
+    gem 'rubocop', '~> 0.59.2', platforms: :mri
     gem 'rubocop-rspec', '~> 1.29.1', platforms: :mri
   end
   if ruby_version >= Gem::Version.new('2.0')

--- a/lib/sanitize_email/bleach.rb
+++ b/lib/sanitize_email/bleach.rb
@@ -27,7 +27,9 @@ module SanitizeEmail
       message.to = overridden.overridden_to
       message.cc = overridden.overridden_cc
       message.bcc = overridden.overridden_bcc
-      message['personalizations'].value = overridden.overridden_personalizations unless message['personalizations'].nil?
+
+      return if message['personalizations'].nil?
+      message['personalizations'].value = overridden.overridden_personalizations
     end
 
     # Will be called by the Hook to determine if an override should occur

--- a/lib/sanitize_email/bleach.rb
+++ b/lib/sanitize_email/bleach.rb
@@ -17,6 +17,7 @@ module SanitizeEmail
     # If all recipient addresses are white-listed the field is left alone.
     def self.delivering_email(message)
       return nil unless sanitize_engaged?(message)
+
       SanitizeEmail::MailHeaderTools.
         add_original_addresses_as_headers(message)
       SanitizeEmail::MailHeaderTools.
@@ -28,8 +29,9 @@ module SanitizeEmail
       message.cc = overridden.overridden_cc
       message.bcc = overridden.overridden_bcc
 
-      return if message["personalizations"].nil?
-      message["personalizations"].value = overridden.overridden_personalizations
+      return if message['personalizations'].nil?
+
+      message['personalizations'].value = overridden.overridden_personalizations
     end
 
     # Will be called by the Hook to determine if an override should occur

--- a/lib/sanitize_email/bleach.rb
+++ b/lib/sanitize_email/bleach.rb
@@ -27,6 +27,7 @@ module SanitizeEmail
       message.to = overridden.overridden_to
       message.cc = overridden.overridden_cc
       message.bcc = overridden.overridden_bcc
+      message['personalizations'].value = overridden.overridden_personalizations unless message['personalizations'].nil?
     end
 
     # Will be called by the Hook to determine if an override should occur

--- a/lib/sanitize_email/bleach.rb
+++ b/lib/sanitize_email/bleach.rb
@@ -28,8 +28,8 @@ module SanitizeEmail
       message.cc = overridden.overridden_cc
       message.bcc = overridden.overridden_bcc
 
-      return if message['personalizations'].nil?
-      message['personalizations'].value = overridden.overridden_personalizations
+      return if message["personalizations"].nil?
+      message["personalizations"].value = overridden.overridden_personalizations
     end
 
     # Will be called by the Hook to determine if an override should occur

--- a/lib/sanitize_email/overridden_addresses.rb
+++ b/lib/sanitize_email/overridden_addresses.rb
@@ -33,8 +33,9 @@ module SanitizeEmail
       @overridden_to = to_override(message.to)
       @overridden_cc = cc_override(message.cc)
       @overridden_bcc = bcc_override(message.bcc)
-      return if message['personalizations'].nil?
-      @overridden_personalizations = personalizations_override(message['personalizations'])
+      return if message["personalizations"].nil?
+      @overridden_personalizations =
+        personalizations_override(message["personalizations"])
     end
 
     # Allow good listed email addresses, and then remove the bad listed addresses
@@ -61,9 +62,15 @@ module SanitizeEmail
     def personalizations_override(actual_personalizations)
       actual_personalizations.unparsed_value.map do |actual_personalization|
         actual_personalization.merge(
-          :to => actual_personalization[:to]&.map { |to| to.merge(:email => override_email(:to, to[:email]).join(',')) },
-          :cc => actual_personalization[:cc]&.map { |cc| cc.merge(:email => override_email(:cc, cc[:email]).join(',')) },
-          :bcc => actual_personalization[:bcc]&.map { |bcc| bcc.merge(:email => override_email(:bcc, bcc[:email]).join(',')) }
+          to: actual_personalization[:to]&.map do |to|
+            to.merge(:email => override_email(:to, to[:email]).join(','))
+          end,
+          cc: actual_personalization[:cc]&.map do |cc|
+            cc.merge(:email => override_email(:cc, cc[:email]).join(','))
+          end,
+          bcc: actual_personalization[:bcc]&.map do |bcc|
+            bcc.merge(:email => override_email(:bcc, bcc[:email]).join(','))
+          end
         )
       end
     end

--- a/lib/sanitize_email/overridden_addresses.rb
+++ b/lib/sanitize_email/overridden_addresses.rb
@@ -58,11 +58,11 @@ module SanitizeEmail
 
     def personalizations_override(actual_personalizations)
       actual_personalizations.unparsed_value.map do |actual_personalization|
-        actual_personalization.merge({
-          to: actual_personalization[:to]&.map{|to| to.merge({email: override_email(:to, to[:email]).join(',')})},
-          cc: actual_personalization[:cc]&.map{|cc| cc.merge({email: override_email(:cc, cc[:email]).join(',')})},
-          bcc: actual_personalization[:bcc]&.map{|bcc| bcc.merge({email: override_email(:bcc, bcc[:email]).join(',')})}
-        })
+        actual_personalization.merge(
+          :to => actual_personalization[:to]&.map { |to| to.merge(:email => override_email(:to, to[:email]).join(',')) },
+          :cc => actual_personalization[:cc]&.map { |cc| cc.merge(:email => override_email(:cc, cc[:email]).join(',')) },
+          :bcc => actual_personalization[:bcc]&.map { |bcc| bcc.merge(:email => override_email(:bcc, bcc[:email]).join(',')) }
+        )
       end
     end
 

--- a/lib/sanitize_email/overridden_addresses.rb
+++ b/lib/sanitize_email/overridden_addresses.rb
@@ -33,9 +33,10 @@ module SanitizeEmail
       @overridden_to = to_override(message.to)
       @overridden_cc = cc_override(message.cc)
       @overridden_bcc = bcc_override(message.bcc)
-      return if message["personalizations"].nil?
+      return if message['personalizations'].nil?
+
       @overridden_personalizations =
-        personalizations_override(message["personalizations"])
+        personalizations_override(message['personalizations'])
     end
 
     # Allow good listed email addresses, and then remove the bad listed addresses
@@ -48,6 +49,7 @@ module SanitizeEmail
     def to_override(actual_addresses)
       to = override_email(:to, actual_addresses)
       raise MissingTo, "after overriding :to (#{actual_addresses}) there are no addresses to send in To: header." if to.empty?
+
       to.join(',')
     end
 
@@ -62,14 +64,14 @@ module SanitizeEmail
     def personalizations_override(actual_personalizations)
       actual_personalizations.unparsed_value.map do |actual_personalization|
         actual_personalization.merge(
-          to: actual_personalization[:to]&.map do |to|
-            to.merge(email: override_email(:to, to[:email]).join(","))
+          :to => actual_personalization[:to]&.map do |to|
+            to.merge(:email => override_email(:to, to[:email]).join(','))
           end,
-          cc: actual_personalization[:cc]&.map do |cc|
-            cc.merge(email: override_email(:cc, cc[:email]).join(","))
+          :cc => actual_personalization[:cc]&.map do |cc|
+            cc.merge(:email => override_email(:cc, cc[:email]).join(','))
           end,
-          bcc: actual_personalization[:bcc]&.map do |bcc|
-            bcc.merge(email: override_email(:bcc, bcc[:email]).join(","))
+          :bcc => actual_personalization[:bcc]&.map do |bcc|
+            bcc.merge(:email => override_email(:bcc, bcc[:email]).join(','))
           end
         )
       end

--- a/lib/sanitize_email/overridden_addresses.rb
+++ b/lib/sanitize_email/overridden_addresses.rb
@@ -63,13 +63,13 @@ module SanitizeEmail
       actual_personalizations.unparsed_value.map do |actual_personalization|
         actual_personalization.merge(
           to: actual_personalization[:to]&.map do |to|
-            to.merge(:email => override_email(:to, to[:email]).join(','))
+            to.merge(email: override_email(:to, to[:email]).join(","))
           end,
           cc: actual_personalization[:cc]&.map do |cc|
-            cc.merge(:email => override_email(:cc, cc[:email]).join(','))
+            cc.merge(email: override_email(:cc, cc[:email]).join(","))
           end,
           bcc: actual_personalization[:bcc]&.map do |bcc|
-            bcc.merge(:email => override_email(:bcc, bcc[:email]).join(','))
+            bcc.merge(email: override_email(:bcc, bcc[:email]).join(","))
           end
         )
       end

--- a/lib/sanitize_email/overridden_addresses.rb
+++ b/lib/sanitize_email/overridden_addresses.rb
@@ -16,7 +16,8 @@ module SanitizeEmail
 
     REPLACE_AT = [/@/, ' at '].freeze
     REPLACE_ALLIGATOR = [/[<>]/, '~'].freeze
-    attr_accessor :overridden_to, :overridden_cc, :overridden_bcc, :overridden_personalizations,
+    attr_accessor :overridden_to, :overridden_cc, :overridden_bcc,
+                  :overridden_personalizations,
                   :good_list, # White-listed addresses will not be molested as to, cc, or bcc
                   :bad_list, # Black-listed addresses will be removed from to, cc and bcc when sanitization is engaged
                   :sanitized_to, :sanitized_cc, :sanitized_bcc # Replace non-white-listed addresses with these sanitized addresses.
@@ -32,7 +33,8 @@ module SanitizeEmail
       @overridden_to = to_override(message.to)
       @overridden_cc = cc_override(message.cc)
       @overridden_bcc = bcc_override(message.bcc)
-      @overridden_personalizations = personalizations_override(message['personalizations']) unless message['personalizations'].nil?
+      return if message['personalizations'].nil?
+      @overridden_personalizations = personalizations_override(message['personalizations'])
     end
 
     # Allow good listed email addresses, and then remove the bad listed addresses

--- a/spec/sanitize_email_spec.rb
+++ b/spec/sanitize_email_spec.rb
@@ -157,6 +157,37 @@ describe SanitizeEmail do
     end
   end
 
+  # def mail_delivery_multiple_personalizations
+  #   @email_message = Mail.deliver do
+  #     @email_message = Mail.deliver do
+  #       from      'from@example.org'
+  #       to        %w[to1@example.org to2@example.org to3@example.org]
+  #       cc        %w[cc1@example.org cc2@example.org cc3@example.org]
+  #       bcc       %w[bcc1@example.org bcc2@example.org bcc3@example.org]
+  #       reply_to  'reply_to@example.org'
+  #       subject   'original subject'
+  #       body      'funky fresh'
+  #       personalizations [
+  #         {
+  #           to: 'to1@example.org',
+  #           cc: 'cc1@example.org',
+  #           bcc: 'bcc1@example.org'
+  #         },
+  #         {
+  #           to: 'to2@example.org',
+  #           cc: 'cc2@example.org',
+  #           bcc: 'bcc2@example.org'
+  #         },
+  #         {
+  #           to: 'to3@example.org',
+  #           cc: 'cc3@example.org',
+  #           bcc: 'bcc3@example.org'
+  #         },
+  #       ]
+  #     end
+  #   end
+  # end
+
   before do
     SanitizeEmail::Deprecation.deprecate_in_silence = true
     sanitize_spec_dryer


### PR DESCRIPTION
This adds support for sanitizing the `personalizations` field used by Twilio's SendGrid API. Fixes #73.

I'm not sure how to properly go about testing since the `personalizations` field isn't built into the default Ruby `Mail::Message` class.

I also understand if this technically falls out of the scope of this gem since it only applied to using SendGrid. I could probably make it as a sort of gem "add-on" if that would be welcomed. Definitely open to feedback!