### PR TITLE
Fix issue preventing personalizations from being properly sanitized

### DIFF
--- a/lib/sanitize_email/bleach.rb
+++ b/lib/sanitize_email/bleach.rb
@@ -28,7 +28,8 @@ module SanitizeEmail
 
         return if message["personalizations"].nil?
 
-        message["personalizations"].value = overridden.overridden_personalizations
+        message["personalizations"] = nil
+        message["personalizations"] = overridden.overridden_personalizations
       end
 
       # Will be called by the Hook to determine if an override should occur


### PR DESCRIPTION
The `personalizations` field used by [sendgrid-actionmailer](https://github.com/eddiezane/sendgrid-actionmailer) relies on the `Message::Field`'s `unparsed_value` method, which cannot be set directly unlike `value`. This PR solves this by setting the `personalizations` field directly rather than setting just `value`.